### PR TITLE
Move heat bed processing inside macro

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -160,14 +160,18 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
     case ID_P_ABS:
       if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
+      #if HAS_HEATED_BED
       else if (uiCfg.curTempType == 1)
         thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
+      #endif  //HAS_HEATED_BED
       break;
     case ID_P_PLA:
       if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
+      #if HAS_HEATED_BED
       else if (uiCfg.curTempType == 1)
         thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
+      #endif  //HAS_HEATED_BED
       break;
   }
 }


### PR DESCRIPTION
### Description

With my configuration (with no heat bed) I'm getting compilation error. This changes fixes it by moving undefined function `thermalManager.setTargetBed(...)` inside conditional macro, which will be included to build only if heat bed exists

### Requirements

To check that compilation fails you don't need anything except my config files. I tested my solution on MKS robin nano 1.2 with display:
 
![image](https://user-images.githubusercontent.com/22222390/136863252-6524a844-7f38-45b4-82c9-ebb82af8ab9e.png)


### Benefits

Resolve compilation error

### Configurations

[configs.zip](https://github.com/saloid/Marlin/files/7325634/configs.zip)

